### PR TITLE
Deprecated SurfaceTracker

### DIFF
--- a/docs/appendix_a.rst
+++ b/docs/appendix_a.rst
@@ -102,7 +102,7 @@ attributes that should not be copied
 
 ``clone_parent_cluster_2_child_cluster`` - used in mitosis with compartmentalized
 cells. Copies all attributes from cell in a parent cluster to
-corresponging cell in the child cluster
+corresponding cell in the child cluster
 
 ``cluster_list`` - Python-iterable list of clusters. Obsolete
 

--- a/docs/appendix_b.rst
+++ b/docs/appendix_b.rst
@@ -59,8 +59,7 @@ Volume Plugin
 
 ``subtype`` - currently unused
 
-``surface`` - instantaneous cell surface. Needs Surface or SurfaceTracker
-plugin
+``surface`` - instantaneous cell surface. Needs Surface plugin
 
 ``targetClusterSurface`` - target value of cluster surface constraint.Needs
 ClusterSurface Plugin

--- a/docs/volume_and_surface_tracker_plugins.rst
+++ b/docs/volume_and_surface_tracker_plugins.rst
@@ -6,22 +6,45 @@ Related: `Global Volume and Surface Constraints <global_volume_and_surface_plugi
 These two plugins monitor the lattice and update the volume and surface of the
 cells once a pixel copy occurs. In most cases, users will not call those
 plugins directly. They will be called automatically when either Volume
-(calls ``VolumeTracker``) or Surface (calls ``SurfaceTracker``) or
+(together with ``VolumeTracker``) or Surface or
 ``CenterOfMass`` (calls ``VolumeTracker``) plugins are requested. However, one
 should be aware that in some situations, for example when doing foam
 coarsening, where neither ``Volume`` nor ``Surface`` plugins are called, one may
 still want to track changes in surface or volume of cells. In such
-situations, we explicitly invoke ``VolumeTracker`` or ``Surface Tracker`` plugin
+situations, we explicitly invoke the ``VolumeTracker`` or ``Surface`` plugins
 with the following syntax:
 
 .. code-block:: xml
 
-    <Plugin Name=”VolumeTracker”/>
+    <Plugin Name="VolumeTracker"/>
 
-or
+As of version 4.6.0, all you have to do to the ``Surface`` plugin
+to enable this behavior is add ``NeighborOrder``.
 
 .. code-block:: xml
 
-    <Plugin Name=”SurfaceTracker”/>
+    <Plugin Name="Surface">
+        <TargetSurface>120</TargetSurface>
+        <LambdaSurface>0.5</LambdaSurface>
+        <NeighborOrder>4</NeighborOrder>
+    </Plugin>
 
 This will enable you to access the current volume and surface in Python with ``cell.volume`` and ``cell.surface``.
+
+.. note:: 
+
+    **Legacy Version (Pre 4.6.0)**
+
+    Previously, this arrangement of plugins was required.
+    ``SurfaceTracker`` is now deprecated. 
+    
+    .. code-block:: xml
+
+        <Plugin Name="SurfaceTracker">
+            <NeighborOrder>4</NeighborOrder>
+        </Plugin>
+
+        <Plugin Name="Surface">
+            <TargetSurface>120</TargetSurface>
+            <LambdaSurface>0.5</LambdaSurface>
+        </Plugin>


### PR DESCRIPTION
This provides guidance for this PR: https://github.com/CompuCell3D/CompuCell3D/pull/702
VolumeTracker is still the same... a little confusing... maybe we should simplify that one as well?